### PR TITLE
Fixed a relative path issue when process.cwd() is not a working_directory

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -21,7 +21,8 @@ FS.prototype.require = function(import_path, search_path) {
     if (import_path.indexOf(this.working_directory) != 0) {
       return null;
     }
-    import_path = "./" + import_path.replace(this.working_directory);
+  } else {
+    search_path = path.join(this.working_directory, search_path);
   }
 
   try {


### PR DESCRIPTION
I've got a problem with `truffle migrate`. When applying migrations, `process.cwd()` has value of the migrations directory and `artifacts.require()` fails because `fs.readFileSync()` can’t find a relative path.

I also removed unnecessary modification of the `import_path` variable in case it’s an absolute path.